### PR TITLE
Add Laravel 8 backend and Bootstrap frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # SAPB1AnalyticsChatBot
+
+This repository contains a simple Laravel 8 backend and a Bootstrap based frontend skeleton. The backend exposes an example API endpoint while the frontend demonstrates calling it.
+
+## Requirements
+- PHP 7.3 or higher
+- Composer
+
+## Setup
+
+1. Install PHP dependencies:
+   ```bash
+   cd backend
+   composer install
+   cp .env.example .env
+   php artisan key:generate
+   ```
+
+2. Start the development server:
+   ```bash
+   php artisan serve
+   ```
+   The API will be available at `http://localhost:8000`.
+
+3. Open the frontend
+   ```bash
+   cd ../frontend
+   php -S localhost:8080
+   ```
+   Navigate to `http://localhost:8080` in your browser.
+
+## NLP Integration
+
+The backend includes a stub service at `app/Services/NLPService.php` where integration with a local NLP model can be implemented.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+DB_CONNECTION=sqlite
+DB_DATABASE=database/database.sqlite
+
+CACHE_DRIVER=file
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=file
+SESSION_LIFETIME=120

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.env

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule)
+    {
+        // $schedule->command('inspire')->hourly();
+    }
+
+    protected function commands()
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}

--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $dontReport = [];
+
+    protected $dontFlash = [
+        'password',
+        'password_confirmation',
+    ];
+
+    public function register()
+    {
+        $this->reportable(function (Throwable $e) {
+            //
+        });
+    }
+}

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/backend/app/Http/Controllers/ExampleController.php
+++ b/backend/app/Http/Controllers/ExampleController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Services\NLPService;
+
+class ExampleController extends Controller
+{
+    public function hello(Request $request, NLPService $nlp)
+    {
+        $text = $request->query('text', 'world');
+        $processed = $nlp->process($text);
+        return response()->json(['message' => $processed]);
+    }
+}

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    protected $middlewareGroups = [
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+
+    protected $routeMiddleware = [
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+    ];
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        // Bind services here
+    }
+
+    public function boot()
+    {
+        // Bootstrap services
+    }
+}

--- a/backend/app/Services/NLPService.php
+++ b/backend/app/Services/NLPService.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services;
+
+class NLPService
+{
+    public function process(string $text): string
+    {
+        // TODO: connect to local NLP model
+        return "Processed: " . $text;
+    }
+}

--- a/backend/artisan
+++ b/backend/artisan
@@ -1,0 +1,17 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+$kernel->terminate($input, $status);
+
+exit($status);

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+$app = new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+$app->register(App\Providers\AppServiceProvider::class);
+
+return $app;

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "sapb1analytics/chatbot-backend",
+    "description": "Laravel 8 Backend for Chatbot",
+    "type": "project",
+    "require": {
+        "php": "^7.3|^8.0",
+        "laravel/framework": "^8.0",
+        "fideloper/proxy": "^4.4",
+        "fruitcake/laravel-cors": "^2.0",
+        "guzzlehttp/guzzle": "^7.0.1",
+        "laravel/tinker": "^2.5"
+    },
+    "require-dev": {
+        "facade/ignition": "^2.5",
+        "fakerphp/faker": "^1.9.1",
+        "mockery/mockery": "^1.4.4",
+        "nunomaduro/collision": "^5.0",
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "@php artisan key:generate --ansi"
+        ]
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'name' => env('APP_NAME', 'Laravel'),
+    'env' => env('APP_ENV', 'production'),
+    'debug' => (bool) env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+    'timezone' => 'UTC',
+    'locale' => 'en',
+    'fallback_locale' => 'en',
+    'key' => env('APP_KEY'),
+    'cipher' => 'AES-256-CBC',
+    'providers' => [
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        App\Providers\AppServiceProvider::class,
+    ],
+];

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,0 +1,15 @@
+<?php
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+
+$response = $kernel->handle(
+    $request = Illuminate\Http\Request::capture()
+)->send();
+
+$kernel->terminate($request, $response);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ExampleController;
+
+Route::get('/hello', [ExampleController::class, 'hello']);

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('inspire', function () {
+    $this->comment(Inspiring::quote());
+})->purpose('Display an inspiring quote');

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Chatbot Frontend</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+    <h1 class="mb-4">Chatbot</h1>
+    <div class="input-group mb-3">
+        <input type="text" id="userInput" class="form-control" placeholder="Type something">
+        <div class="input-group-append">
+            <button class="btn btn-primary" onclick="send()">Send</button>
+        </div>
+    </div>
+    <pre id="response" class="border p-3"></pre>
+</div>
+<script>
+function send() {
+    const text = document.getElementById('userInput').value;
+    fetch('../backend/public/index.php/api/hello?text=' + encodeURIComponent(text))
+        .then(r => r.json())
+        .then(d => document.getElementById('response').textContent = d.message)
+        .catch(err => document.getElementById('response').textContent = 'Error: ' + err);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal Laravel 8 project under `backend/`
- add NLP service stub
- add a simple Bootstrap frontend
- document setup and development server instructions in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68498ec23308832c86912cf5730e0d4f